### PR TITLE
Relaxed Swarm implementation from Hive

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Setup
 Dependencies:
 - Linux on x86_64: We've tested with Ubuntu 14.04, 16.04, and 18.04.
   If you want to run this in a VM, see Vagrant setup below.
-- GCC: Version 4.8 or newer will suffice to build the simulator itself, which
+- GCC: Version >= 4.8 and <= 9.5 will suffice to build the simulator itself, which
   is written in C++11 and depends on a particular GCC ABI.  (Clang won't work.)
   Test applications are written in C++14 so they can build with GCC 5+ or Clang.
 - Pin version 2.14: Download this from

--- a/sim/init/init.cpp
+++ b/sim/init/init.cpp
@@ -916,6 +916,8 @@ static void InitSystem(const Config& config) {
     initinfo->usePreciseAddressSets = ("Precise" == std::string(
                 config.get<const char*>("sys.robs.addressSet.type", "Bloom")));
 
+    initinfo->relaxed = config.get<bool>("sys.robs.relaxedOrder", false);
+
     uint32_t maxFrameDepth =
         config.get<uint32_t>("sys.robs.maxFrameDepth", UINT32_MAX);
     //FIXME(victory): Remove this hack when we have a less-broken

--- a/sim/rob.cpp
+++ b/sim/rob.cpp
@@ -1017,10 +1017,10 @@ TaskPtr ROB::removeUntiedTaskImpl(const uint64_t taskFn,
     // FIXME(dsm): Use multi-index::range()
     auto start =
              boost::make_reverse_iterator(runQueue.lower_bound(
-                  std::make_tuple(std::cref(maxTS), false)));
+                  std::make_tuple(std::cref(maxTS), 0, false)));
     auto end =
              boost::make_reverse_iterator(runQueue.lower_bound(
-                         std::make_tuple(std::cref(minTS), false)));
+                         std::make_tuple(std::cref(minTS), 0, false)));
 
     // For liveness: we don't want to spill the minimum task.
     // Spilling that task would certainly induce a swarm::requeuer(...) of
@@ -1284,7 +1284,8 @@ std::pair<TaskPtr, rob::Stall> ROB::taskToRun(ThreadID tid) {
         // Find all tasks with the same timestamp, including all producers
         TimeStamp ubTs = runQueue.min()->lts();
         ubTs.clearTieBreaker();
-        auto ub = runQueue.upper_bound(std::make_tuple(std::cref(ubTs), true));
+        auto ub = runQueue.upper_bound(std::make_tuple(std::cref(ubTs), 
+		runQueue.min()->softTs, true));
         ub = std::prev(ub);
 
         // Manually check if std::distance(rq.begin(), ub) < underflow.

--- a/sim/robtypes.h
+++ b/sim/robtypes.h
@@ -37,11 +37,11 @@ using ExecQ_ty = fixed_capacity_ordered_set<
 
 // The RunQ sorts tasks by their timestamp and deprioritizes producers. It uses
 // a global_fun key extractor to allow calls to lower/upper_bound to use keys.
-using RunQ_key_ty = std::tuple<const TimeStamp&, uint8_t>;
+using RunQ_key_ty = std::tuple<const TimeStamp&, uint64_t, uint8_t>;
 inline RunQ_key_ty getRunQKey(const TaskPtr& t) {
     // Given an equal choice between running a programmer-defined producer and a
     // requeuer, choose the normal producer
-    return std::make_tuple(std::cref(t->lts()),
+    return std::make_tuple(std::cref(t->lts()), t->softTs,
                            (t->isProducer() << 1) | t->isRequeuer());
 }
 using RunQ_ty = ordered_pointer_set<TaskPtr, ordered_non_unique<global_fun<const TaskPtr&, RunQ_key_ty, getRunQKey>>, RunQ_key_ty>;

--- a/sim/sim.h
+++ b/sim/sim.h
@@ -155,6 +155,8 @@ struct GlobSimInfo {
     std::vector<ROB*> robs;
     std::vector<TSB*> tsbs;
     std::vector<ThreadThrottlerUnit*> throttlers;
+
+    bool relaxed;
 };
 
 extern const GlobSimInfo* ossinfo;

--- a/sim/task.h
+++ b/sim/task.h
@@ -165,7 +165,7 @@ public:
     // Unordered tasks indicated as using soft priority will take on the programmer-
     // specified timestamp as their soft timestamp, meaning that the tasks will be
     // dequeued in the soft timestamp order.
-    const uint64_t softTs;
+    uint64_t softTs;
 
     // Must this task be executed speculatively? Can it be run speculatively,
     // but also non-speculatively when its parent commits and assuming perfect

--- a/sim/virt/virt.cpp
+++ b/sim/virt/virt.cpp
@@ -27,6 +27,7 @@
 /* This file was adapted from zsim. */
 
 #include <syscall.h>
+#include <errno.h>
 #include "sim/log.h"
 #include "sim/sim.h"
 #include "sim/virt/virt.h"
@@ -57,7 +58,38 @@ bool syscallEnter(spin::ThreadId tid, spin::ThreadContext* ctxt) {
     uint64_t syscall = spin::getReg(ctxt, REG_RAX);
     DEBUG("[%d] syscall %ld", tid, syscall);
 
+     // glibc version 2.28+, if built with GCC's -fcf-protection, will have
+     // init_cpu_features() (which runs early on during the execution of any
+     // process) attempt to call the nonexisting ARCH_CET_STATUS (0x3001)
+     // subfunction of arch_prctl.  See:
+     // https://sourceware.org/git/?p=glibc.git;a=commit;h=394df3815e8ceec750fd06583eee4896174ce808
+     // This became the default in Ubuntu 19.10+.  See:
+     // https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-fcf-protection
+     // Pin v2.14 crashes when it sees this unexpected arch_prctl subfunction.
+     // Avoid the crash by just pretending to execute the syscall instruction
+     // while skipping over it.
+     if (syscall == SYS_arch_prctl && spin::getReg(ctxt, REG_RDI) == 0x3001) {
+	     DEBUG("[%d] ignoring prtcl", tid);
+     	spin::setReg(ctxt, REG::REG_RIP,
+                 spin::getReg(ctxt, REG::REG_RIP) +
+                      2/*bytes in fast system call instruction*/);
+        spin::setReg(ctxt, REG::REG_RAX,
+                     -1UL/*indicates failure of syscall, as glibc expects*/);
+        return false;
+    }
+
+    //clone3 syscall used by glibc in ubuntu 22.04 when spawning threads fails
+    //here, but will fallback to clone if errno is ENOSYS
+    //
+    //So pretend to fail with this errno, similar to above
+    if (syscall == SYS_clone3) {
+	spin::setReg(ctxt, REG_RAX, -ENOSYS);
+	spin::setReg(ctxt, REG_RIP, spin::getReg(ctxt, REG_RIP) + 2);
+	return false;
+    }
+
     if (!IsInFastForward()) {
+	    DEBUG("[%d] non-ff syscall", tid);
       // Perform reads/writes to syscall input/output data to reflect its memory
       // behavior. This avoids conflicts on syscall data.
       if (syscall == SYS_read) {
@@ -98,6 +130,7 @@ bool syscallEnter(spin::ThreadId tid, spin::ThreadContext* ctxt) {
         default: break;
     }
     if (keepThreadCaptured) syncSyscallTid = tid;
+    DEBUG("[%d] returning %d", tid, !keepThreadCaptured);
     return !keepThreadCaptured;
 }
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -19,20 +19,23 @@ env.Append(CFLAGS = ['-std=c11', '-Wstrict-prototypes'])
 # https://wiki.debian.org/Hardening
 # Let's fight the nanny distros and try to get more consistent behavior
 # by disabling new security-related compiler features.
-#
-# Ubuntu 14.10 and later systems enable -fstack-protector-strong by default.
-# This generates extra accesses to thread-local storage to get canary values
-# that are placed on the stack.  We want to avoid these memory accesses,
-# which incur needless conflict checks:
 env.Append(CPPFLAGS = ['-fno-stack-protector'])
-# Ubuntu 16.10 and later systems enable PIE by default, which is incompatible
-# with the local labels within inline asm in the Swarm runtime.
 if not GetOption('clang'):
     env.Append(CPPFLAGS = ['-no-pie', '-fno-PIE'])
     env.Append(LINKFLAGS = ['-no-pie', '-fno-PIE'])
-# Ubuntu 19.10 enables -fstack-clash-protection and -fcf-protection by default.
+print('Checking whether compiler supports stack-clash prevention and Intel CET...')
 # These flags don't exist prior to GCC 8.
+testEnv = env.Clone()
 #env.Append(CPPFLAGS = ['-fno-stack-clash-protection', '-fcf-protection=none'])
+testEnv.Append(CPPFLAGS = ['-fno-stack-clash-protection', '-fcf-protection=none'])
+conf = Configure(testEnv)
+flagsAreSupported = conf.CheckCXX()
+testEnv = conf.Finish()
+if flagsAreSupported:
+    env = testEnv
+else:
+    # CheckCXX() printed a scary message upon failure. Tell the user not to worry.
+    print('^That failure is good. Continuing with build.')
 
 env.Append(LIBS = ['pthread'])
 


### PR DESCRIPTION
This adds the relaxed Swarm implementation from the Hive paper.  

The config option relaxedOrder causes all tasks to use softPrio, which is implemented so that tasks are ordered by softTs if their timestamps are equal, and all tasks with softPrio get timestamp 0 and softTs = appTs.

The result is that tasks get the same app-level TS that they would otherwise and continue to dequeue in order, but can commit out of order, while retaining atomicity.  Aborts can still happen between simultaneous conflicting tasks similarly to TM.